### PR TITLE
Fix for missing interpolation argument :msg 

### DIFF
--- a/frontend/controllers/resources_updates_controller.rb
+++ b/frontend/controllers/resources_updates_controller.rb
@@ -108,7 +108,7 @@ Pry::ColorPrinter.pp "Got the HEADERS!"
             @error_level = nil
 #            Pry::ColorPrinter.pp "no ao" if !ao
           rescue StopExcelImportException => se
-            @report.add_errors([se.message, I18n.t('plugins.aspace-import-excel.error.stopped', :row => @counter)])
+            @report.add_errors(I18n.t('plugins.aspace-import-excel.error.stopped', :row => @counter, :msg => se.message))
             raise StopIteration.new
           rescue ExcelImportException => e
             @error_rows += 1


### PR DESCRIPTION
I saw missing interpolation argument error when an import job failed.

Error:
Processing stopped at row 4 [Some system error has occurred [missing interpolation argument :msg in "Processing stopped at row %{row} [%{msg}]" ({row=>4} given].]

Solution:
Added a second parameter :msg => se.message to I18n.t() method call.