### PR TITLE
Fix AgentHandler.renew method never being called.

### DIFF
--- a/frontend/controllers/resources_updates_controller.rb
+++ b/frontend/controllers/resources_updates_controller.rb
@@ -408,6 +408,7 @@ Rails.logger.info {ao.pretty_inspect}
     ContainerInstanceHandler.renew
     DigitalObjectHandler.renew
     SubjectHandler.renew
+    AgentHandler.renew
   end
   
   # set up all the @ variables (except for @header)


### PR DESCRIPTION
Added call to AgentHandler::renew to initialize_handler_enums method of ResourcesUpdatesController.