### PR TITLE
Fully support prefixes

### DIFF
--- a/frontend/assets/tree_extensions.js
+++ b/frontend/assets/tree_extensions.js
@@ -85,7 +85,7 @@ $(function () {
 	    $form = $("#bulk_ingest_form");
 	    rid = $form.find("#rid").val();
 	    /* I do this because ajaxSubmit doesn't like the URL property? */
-	    $form.attr("action", "/resources/" + rid + "/ssload");
+	    $form.attr("action", APP_PATH + "resources/" + rid + "/ssload");
 	    $form.ajaxSubmit({
 	       type: "POST",
 	       beforeSubmit:  function(arr, $form, options) {

--- a/frontend/controllers/resources_updates_controller.rb
+++ b/frontend/controllers/resources_updates_controller.rb
@@ -57,8 +57,8 @@ Rails.logger.info "ao instances? #{!ao["instances"].blank?}" if ao
     @digital_load  = params.fetch(:digital_load,'') == 'true'
 
     if @digital_load
-      @find_uri =  "/repositories/#{params[:repo_id]}/find_by_id/archival_objects"
-      @resource_ref = "/repositories/#{params[:repo_id]}/resources/#{params[:id]}"
+      @find_uri =  "#{AppConfig[:frontend_proxy_prefix]}repositories/#{params[:repo_id]}/find_by_id/archival_objects"
+      @resource_ref = "#{AppConfig[:frontend_proxy_prefix]}repositories/#{params[:repo_id]}/resources/#{params[:id]}"
       @repo_id = params[:repo_id]
       @start_marker = DO_START_MARKER
     else

--- a/frontend/views/resources/_bulk_file_form.html.erb
+++ b/frontend/views/resources/_bulk_file_form.html.erb
@@ -1,7 +1,7 @@
 <div id="bulk_ingest_file_template">
   <div class="bulk_ingest_wrapper">
 <!-- <%= "/resources/#{rid}/ssload" %> -->
-    <%= form_tag('/resources/ssload', method: "post", id: "bulk_ingest_form", multipart: true) do |form| %>
+    <%= form_tag url_for("#{AppConfig[:frontend_proxy_prefix]}resources/ssload"), :method => "post", multipart: true, :id => 'bulk_ingest_form' do %>
 <!-- <%= "#{rid}  #{ref_id}" %> -->
     <div class="modal-body">
 	 <input type='hidden' name='repo_id' id='repo_id' value='<%= repo_id %>'/>


### PR DESCRIPTION
@bobbi-SMR this is a _mea culpa_ on my part. I only loaded a spreadsheet without a path prefix applied to confirm the plugin still worked (as expected with the prefix scope added) and didn't anticipate there would be other parts of the code directly generating a path. So I've updated all of those and test loaded data with and without prefix and had a user of the plugin verify it on their site. Sorry about that, I should have been more thorough the first time around.

We're deploying from my fork until you have time to review so there's absolutely no rush / hold up on our end.