### PR TITLE
Issue 51

### DIFF
--- a/frontend/controllers/concerns/linked_objects.rb
+++ b/frontend/controllers/concerns/linked_objects.rb
@@ -53,7 +53,7 @@ module LinkedObjects
               agent_obj = get_db_agent(agent, resource_uri, num)
             rescue Exception => e
               if e.message == 'More than one match found in the database'
-                agent[:name] = agent[:name] + " DISAMBIGUATE ME!"
+                agent[:name] = agent[:name] + DISAMB_STR
                 report.add_info(I18n.t('plugins.aspace-import-excel.warn.disam', :name => agent[:name]))
               else
                 raise e
@@ -94,7 +94,7 @@ module LinkedObjects
     begin
       ret_agent = JSONModel("agent_#{agent[:type]}".to_sym).new._always_valid!
       ret_agent.names = [name_obj(agent)]
-      ret_agent.publish = !agent[:id_but_no_name]
+      ret_agent.publish = !(agent[:id_but_no_name] || agent[:name].ends_with?(DISAMB_STR))
       ret_agent.save
     rescue Exception => e
        raise Exception.new(I18n.t('plugins.aspace-import-excel.error.no_agent', :num => num, :why => e.message))
@@ -371,7 +371,7 @@ module LinkedObjects
               subj = get_db_subj(subject)
             rescue Exception => e
               if e.message == 'More than one match found in the database'
-                subject[:term] = subject[:term] + " DISAMBIGUATE ME!"
+                subject[:term] = subject[:term] + DISAMB_STR
                 report.add_info(I18n.t('plugins.aspace-import-excel.warn.disam', :name => subject[:term]))
               else
                 raise e
@@ -408,6 +408,7 @@ module LinkedObjects
         subj.terms.push term
         subj.source = subject[:source]
         subj.vocabulary = '/vocabularies/1'  # we're making a gross assumption here
+        subj.publish = !(subject[:id_but_no_term] || subject[:term].ends_with?(DISAMB_STR))
         subj.save
       rescue Exception => e
         raise ExcelImportException.new(I18n.t('plugins.aspace-import-excel.error.no_subject',:num => num, :why => e.message))

--- a/frontend/controllers/concerns/linked_objects.rb
+++ b/frontend/controllers/concerns/linked_objects.rb
@@ -36,13 +36,13 @@ module LinkedObjects
    def self.get_or_create(row, type, num, resource_uri, report)
      agent = build(row, type, num)
      agent_key = key_for(agent)
+     Rails.logger.error("Created Agent: #{agent.pretty_inspect} key: #{agent_key}")
      if !(agent_obj = stored(@@agents, agent[:id], agent_key))
        unless agent[:id].blank?
          begin
            agent_obj = JSONModel("agent_#{agent[:type]}".to_sym).find(agent[:id])
          rescue Exception => e
            if e.message != 'RecordNotFound'
-#             Pry::ColorPrinter.pp e
              raise ExcelImportException.new( I18n.t('plugins.aspace-import-excel.error.no_agent', :num => num, :why => e.message))
            end
          end
@@ -87,6 +87,7 @@ module LinkedObjects
          end
        end
      end
+     Rails.logger.error("AGENTS: #{@@agents.pretty_inspect}")
      agent_link
    end
 

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -28,6 +28,7 @@ en:
       ref_id_notfound: "Ref Id %{refid} not found"
       warn:
        dup: "Managed Controlled Value List %{which} has multiple instances for the Translation '%{trans}'. '%{used}' will be used as the value."
+       disam: "Multiple match(es) found. Creating %{name} for disabiguation."
       error:
        date_type: "Date type [%{what}] invalid. Defaulting to 'inclusive'"
        certainty: "Invalid 'date certainty' ignored: (%{what})"

--- a/frontend/models/handler.rb
+++ b/frontend/models/handler.rb
@@ -11,6 +11,8 @@ class Handler
   require 'enum_list'
   require 'pp'
 
+  DISAMB_STR = ' DISAMBIGUATE ME!'
+
   # centralize the checking for an already-found object
   def self.stored(hash, id, key)
     ret_obj = hash.fetch(id, nil) || hash.fetch(key, nil)
@@ -41,7 +43,7 @@ class Handler
     elsif  total_hits > 1
       if matches.length == 2
         match_ct = 0
-        disam = matches[1] + " DISAMBIGUATE ME!"
+        disam = matches[1] + DISAMB_STR
         disam_obj = nil
         search['results'].each do |result|
           # if we have a disambiguate result get it

--- a/user_documentation/archival_objects_instructions.md
+++ b/user_documentation/archival_objects_instructions.md
@@ -128,11 +128,21 @@ URL of thumbnail| URL String ||  if defined, this becomes the File version with 
 
 The ingester allows you to link Agents (*CREATOR role only!*) to Archival objects.  You can specify up to 3 Person Agents, up to 2 Corporate Agents, and one Family Agent per Archival object.
 
-If you have previously defined the Agent(s) you are using, you may use the Record ID number (e.g.:  for the Agent URI /agents */agent_person/1249*, you would use **1249**) OR the full header header string, with all capitalization and punctuation.
+If you have previously defined the Agent(s) you are using, you may use the Record ID number (e.g.:  for the Agent URI /agents */agent_person/1249*, you would use **1249**) OR the full header string, with all capitalization and punctuation.
 
-Either the Record ID *or* the header string is **required**; if you include both, and the record isn't found, a new Agent record will be created.  The header string will be used as the **family_name** if it's a Family Agent, and the **primary_name**  otherwise.
+Either the Record ID *or* the header string is **required**.
 
-If for some reason you enter a Record ID and **not** the header string, and that ID is not found, a new Agent record will be created with the name "PLACEHOLDER FOR *{agent type}* ID *{ id number}* NOT FOUND", so that you may easily find that record later and edit/merge it. In this case, the new Agent would be marked publish=false. When you correct the record, change publish to true if appropriate.
+If you include both, or only the header, and the record isn't found, a new Agent record will be created.  The header string will be used as the **family_name** if it's a Family Agent, and the **primary_name**  
+otherwise.
+
+If you enter the header string *without* the ID, the ingester will try to do an **exact match** against the header; if it finds more than one match (for example, if the database contains two agents with identical headers, but different sources):
+
+  * The ingester will create a **new** agent (with publish=false) containing the header with ' DISAMBIGUATE ME!' appended to it.  For example, given a person agent with a header of 'George Washington', a new person agent would be created with a primary name of 'George Washington DISAMBIGUATE ME!'.  
+  * After ingest, you can  use the *merge* functionality to resolve the ambiguities.
+
+If you enter a Record ID and **not** the header string, and that ID is not found, a new Agent record will be created with the name "PLACEHOLDER FOR *{agent type}* ID *{ id number}* NOT FOUND", so that you may easily find that record later and edit/merge it. In this case, the new Agent would be marked publish=false. When you correct the record, change publish to true if appropriate.
+
+
 
 #### Person agents:
 
@@ -171,6 +181,11 @@ Corporate Agent/Creator Relator (2)|String||  If supplying relator, term must be
 ### <a name="subject">Subjects</a>
 
 As with <a href="#agent">Agents</a>, you may associate Subjects with the Archival Object.  You may associate up to two Subject records.  If you know the Record ID, you may use that instead of the **term**, **type**, and **source** in a manner similar to the way that Agent specifications are made, with the same database lookup and handling done there.  Again, if you want the ingest to look up the **term** in the database, you must use the entire Subject header, including any punctuation or capitalization.
+
+If you enter the subject header string *without* the ID, the ingester will try to do an **exact match** against the header; if it finds more than one match (for example, if the database contains two subjects with identical headers, but different sources):
+
+  * The ingester will create a **new** agent (with publish=false) containing the header with ' DISAMBIGUATE ME!' appended to it.  For example, given a subject with a header of 'Black Lives Matter', a new subject  would be created with the header  'Black Lives Matter DISAMBIGUATE ME!'.  
+  * After ingest, you can  use the *merge* functionality to resolve the ambiguities.* 
 
 Column | Value | Default | Comment
 -------|-------|---------|---------


### PR DESCRIPTION
Fixes #51 
Code now does exact matching against headers.  For agents and subjects, if there are more than one exact matches, a new agent/subject is created, with the string " Disambiguate me!" appended, and associated with the archival object.  If the disambiguation is not attended to for the next ingest, subsequent occurrences of multiple matches will lead to the " Disambiguate me!" agent/subject being associated with the archival object